### PR TITLE
Add WPF cover art manager

### DIFF
--- a/CoverArtManager/App.xaml
+++ b/CoverArtManager/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="CoverArtManager.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/CoverArtManager/App.xaml.cs
+++ b/CoverArtManager/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace CoverArtManager
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/CoverArtManager/CoverArtManager.csproj
+++ b/CoverArtManager/CoverArtManager.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TagLibSharp" Version="2.2.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+  </ItemGroup>
+</Project>

--- a/CoverArtManager/ViewModels/MainViewModel.cs
+++ b/CoverArtManager/ViewModels/MainViewModel.cs
@@ -1,0 +1,150 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Windows.Media.Imaging;
+using TagLib;
+
+namespace CoverArtManager.ViewModels
+{
+    public partial class MainViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string? audioFilePath;
+        [ObservableProperty]
+        private string? imageFilePath;
+        [ObservableProperty]
+        private BitmapSource? audioImage;
+        [ObservableProperty]
+        private BitmapSource? imagePreview;
+
+        public string? AudioFileName => Path.GetFileName(AudioFilePath);
+        public string? ImageFileName => Path.GetFileName(ImageFilePath);
+
+        partial void OnAudioFilePathChanged(string? value)
+        {
+            OnPropertyChanged(nameof(AudioFileName));
+        }
+
+        partial void OnImageFilePathChanged(string? value)
+        {
+            OnPropertyChanged(nameof(ImageFileName));
+        }
+
+        public void LoadAudio(string path)
+        {
+            AudioFilePath = path;
+            AudioImage = GetAudioCoverArt(path) ?? GetFileIcon(path);
+        }
+
+        public void LoadImage(string path)
+        {
+            ImageFilePath = path;
+            ImagePreview = LoadBitmap(path);
+        }
+
+        private BitmapSource? GetAudioCoverArt(string file)
+        {
+            try
+            {
+                var tfile = TagLib.File.Create(file);
+                if (tfile.Tag.Pictures.Length > 0)
+                {
+                    using var ms = new MemoryStream(tfile.Tag.Pictures[0].Data.Data);
+                    return LoadBitmap(ms);
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private BitmapSource GetFileIcon(string path)
+        {
+            var icon = System.Drawing.Icon.ExtractAssociatedIcon(path);
+            return System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(
+                icon!.Handle,
+                System.Windows.Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
+        }
+
+        private BitmapSource LoadBitmap(string path)
+        {
+            using var fs = File.OpenRead(path);
+            return LoadBitmap(fs);
+        }
+
+        private BitmapSource LoadBitmap(Stream stream)
+        {
+            var bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.StreamSource = stream;
+            bmp.EndInit();
+            bmp.Freeze();
+            return bmp;
+        }
+
+        [RelayCommand]
+        private void Embed()
+        {
+            if (AudioFilePath == null || ImagePreview == null) return;
+            try
+            {
+                var tfile = TagLib.File.Create(AudioFilePath);
+                using var ms = new MemoryStream();
+                var encoder = new PngBitmapEncoder();
+                encoder.Frames.Add(BitmapFrame.Create(ImagePreview));
+                encoder.Save(ms);
+                ms.Position = 0;
+                var pic = new TagLib.Picture(ms.ToArray())
+                {
+                    Type = TagLib.PictureType.FrontCover
+                };
+                tfile.Tag.Pictures = new TagLib.IPicture[] { pic };
+                tfile.Save();
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show($"Failed to embed cover art: {ex.Message}");
+            }
+        }
+
+        [RelayCommand]
+        private void Remove()
+        {
+            if (AudioFilePath == null) return;
+            try
+            {
+                var tfile = TagLib.File.Create(AudioFilePath);
+                tfile.Tag.Pictures = Array.Empty<IPicture>();
+                tfile.Save();
+                AudioImage = GetFileIcon(AudioFilePath);
+            }
+            catch (Exception ex)
+            {
+                System.Windows.MessageBox.Show($"Failed to remove cover art: {ex.Message}");
+            }
+        }
+
+        [RelayCommand]
+        private void Edit()
+        {
+            if (ImagePreview == null) return;
+            var dlg = new Views.CropWindow(ImagePreview);
+            if (dlg.ShowDialog() == true)
+            {
+                ImagePreview = dlg.CroppedBitmap;
+            }
+        }
+
+        [RelayCommand]
+        private void Clear()
+        {
+            AudioFilePath = null;
+            ImageFilePath = null;
+            AudioImage = null;
+            ImagePreview = null;
+        }
+    }
+}

--- a/CoverArtManager/Views/CropWindow.xaml
+++ b/CoverArtManager/Views/CropWindow.xaml
@@ -1,0 +1,27 @@
+<Window x:Class="CoverArtManager.Views.CropWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Crop Image" Height="500" Width="700" WindowStyle="None" ResizeMode="NoResize" Background="#FF16161C">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <DockPanel Background="#FF272730" Height="30" VerticalAlignment="Top" Grid.Row="0">
+            <TextBlock Text="Crop Image" Foreground="White" Margin="5" VerticalAlignment="Center"/>
+            <Button Content="X" Width="30" Height="30" DockPanel.Dock="Right" Click="Close_Click"/>
+        </DockPanel>
+        <Canvas x:Name="Canvas" Grid.Row="1" Background="#FF1E1E25"
+                MouseLeftButtonDown="Canvas_MouseLeftButtonDown"
+                MouseMove="Canvas_MouseMove"
+                MouseLeftButtonUp="Canvas_MouseLeftButtonUp">
+            <Image x:Name="Image"/>
+            <Rectangle x:Name="CropRect" Stroke="Cyan" StrokeThickness="2" Fill="#40C0C0C0"/>
+        </Canvas>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2" Margin="0,10">
+            <Button Content="Apply" Width="80" Margin="5" Click="Apply_Click"/>
+            <Button Content="Cancel" Width="80" Margin="5" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CoverArtManager/Views/CropWindow.xaml.cs
+++ b/CoverArtManager/Views/CropWindow.xaml.cs
@@ -1,0 +1,82 @@
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace CoverArtManager.Views
+{
+    public partial class CropWindow : Window
+    {
+        private Point? startPoint;
+        public BitmapSource CroppedBitmap { get; private set; }
+
+        public CropWindow(BitmapSource source)
+        {
+            InitializeComponent();
+            Image.Source = source;
+            CroppedBitmap = source;
+        }
+
+        private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            startPoint = e.GetPosition(Canvas);
+            Canvas.CaptureMouse();
+            CropRect.Width = CropRect.Height = 0;
+            Canvas.Children.Remove(CropRect);
+            Canvas.Children.Add(CropRect);
+        }
+
+        private void Canvas_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (startPoint.HasValue && e.LeftButton == MouseButtonState.Pressed)
+            {
+                var pos = e.GetPosition(Canvas);
+                var x = Math.Min(pos.X, startPoint.Value.X);
+                var y = Math.Min(pos.Y, startPoint.Value.Y);
+                var w = Math.Abs(pos.X - startPoint.Value.X);
+                var h = Math.Abs(pos.Y - startPoint.Value.Y);
+                Canvas.SetLeft(CropRect, x);
+                Canvas.SetTop(CropRect, y);
+                CropRect.Width = w;
+                CropRect.Height = h;
+            }
+        }
+
+        private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            startPoint = null;
+            Canvas.ReleaseMouseCapture();
+        }
+
+        private void Apply_Click(object sender, RoutedEventArgs e)
+        {
+            if (Image.Source is BitmapSource bmp)
+            {
+                var rect = new Int32Rect(
+                    (int)Canvas.GetLeft(CropRect),
+                    (int)Canvas.GetTop(CropRect),
+                    (int)CropRect.Width,
+                    (int)CropRect.Height);
+                if (rect.Width > 0 && rect.Height > 0)
+                {
+                    var cropped = new CroppedBitmap(bmp, rect);
+                    CroppedBitmap = cropped;
+                }
+            }
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/CoverArtManager/Views/MainWindow.xaml
+++ b/CoverArtManager/Views/MainWindow.xaml
@@ -1,0 +1,41 @@
+<Window x:Class="CoverArtManager.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:CoverArtManager.Views"
+        xmlns:vm="clr-namespace:CoverArtManager.ViewModels"
+        mc:Ignorable="d"
+        Title="Cover Art Manager" Height="600" Width="900"
+        Background="#FF16161C" WindowStyle="None" ResizeMode="CanResize" AllowsTransparency="True">
+    <Window.DataContext>
+        <vm:MainViewModel/>
+    </Window.DataContext>
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Border x:Name="AudioDrop" BorderBrush="Gray" BorderThickness="2" CornerRadius="5" AllowDrop="True"
+                Background="#FF1E1E25" Padding="10" Margin="5" Drop="AudioDrop_Drop" Grid.Column="0">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Width="100" Height="100" Source="{Binding AudioImage}"/>
+                <TextBlock Text="{Binding AudioFileName}" Foreground="White" HorizontalAlignment="Center" Margin="5"/>
+            </StackPanel>
+        </Border>
+        <Border x:Name="ImageDrop" BorderBrush="Gray" BorderThickness="2" CornerRadius="5" AllowDrop="True"
+                Background="#FF1E1E25" Padding="10" Margin="5" Grid.Column="2" Drop="ImageDrop_Drop">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Width="100" Height="100" Source="{Binding ImagePreview}"/>
+                <TextBlock Text="{Binding ImageFileName}" Foreground="White" HorizontalAlignment="Center" Margin="5"/>
+            </StackPanel>
+        </Border>
+        <StackPanel Grid.Column="1" Margin="10" VerticalAlignment="Center" HorizontalAlignment="Center" >
+            <Button Content="Embed Cover Art" Command="{Binding EmbedCommand}" Margin="5" Width="150"/>
+            <Button Content="Remove Cover Art" Command="{Binding RemoveCommand}" Margin="5" Width="150"/>
+            <Button Content="Edit Image" Command="{Binding EditCommand}" Margin="5" Width="150"/>
+            <Button Content="Clear All" Command="{Binding ClearCommand}" Margin="5" Width="150"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CoverArtManager/Views/MainWindow.xaml.cs
+++ b/CoverArtManager/Views/MainWindow.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace CoverArtManager.Views
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void AudioDrop_Drop(object sender, DragEventArgs e)
+        {
+            if (DataContext is ViewModels.MainViewModel vm && e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length > 0)
+                    vm.LoadAudio(files[0]);
+            }
+        }
+
+        private void ImageDrop_Drop(object sender, DragEventArgs e)
+        {
+            if (DataContext is ViewModels.MainViewModel vm && e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length > 0)
+                    vm.LoadImage(files[0]);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# joor
-Lazy wannabe coder
+# Cover Art Manager
+
+This project is a simple WPF application written in C# (.NET 8) that allows
+embedding or removing cover art from common audio formats. It uses TagLib# for
+the metadata operations and follows a basic MVVM architecture with
+CommunityToolkit.Mvvm.
+
+The application provides drag and drop areas for an audio file and an image,
+as well as a cropping dialog to trim the image before embedding. The main
+window is styled with a dark theme.
+
+To build the project locally you need the .NET 8 SDK and can run:
+
+```bash
+cd CoverArtManager
+dotnet build
+```


### PR DESCRIPTION
## Summary
- initialize a new WPF app project `CoverArtManager`
- add MVVM-based `MainViewModel` to handle audio and image loading, embed/remove operations and cropping
- add `MainWindow` UI with drag-and-drop areas and commands
- implement a simple `CropWindow` for selecting a crop area
- update `README` with build instructions

## Testing
- `dotnet build CoverArtManager/CoverArtManager.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842daead4288331a3015e055c2eafd6